### PR TITLE
feature/add-profit-margin

### DIFF
--- a/E-commerce Sales Analysis Query
+++ b/E-commerce Sales Analysis Query
@@ -45,3 +45,58 @@ WHERE
     sale_month = (SELECT MAX(sale_month) FROM monthly_sales) -- Focus on the latest month
 ORDER BY 
     sales_rank;
+
+--Branch
+WITH monthly_sales AS (
+    SELECT 
+        DATE_TRUNC('month', o.order_date) AS sale_month,
+        p.category,
+        SUM(oi.quantity * oi.unit_price) AS total_sales,
+        SUM(oi.quantity * (oi.unit_price - p.cost_price)) AS total_profit
+    FROM 
+        orders o
+        JOIN order_items oi ON o.order_id = oi.order_id
+        JOIN products p ON oi.product_id = p.product_id
+    WHERE 
+        o.order_date >= DATE_TRUNC('year', CURRENT_DATE)
+    GROUP BY 
+        DATE_TRUNC('month', o.order_date),
+        p.category
+),
+prev_month_data AS (
+    SELECT 
+        sale_month,
+        category,
+        total_sales,
+        total_profit,
+        LAG(total_sales) OVER (PARTITION BY category ORDER BY sale_month) AS prev_month_sales,
+        LAG(total_profit) OVER (PARTITION BY category ORDER BY sale_month) AS prev_month_profit
+    FROM 
+        monthly_sales
+)
+SELECT 
+    sale_month,
+    category,
+    total_sales,
+    total_profit,
+    (total_profit / total_sales * 100) AS profit_margin,
+    prev_month_sales,
+    CASE 
+        WHEN prev_month_sales > 0 THEN 
+            ((total_sales - prev_month_sales) / prev_month_sales * 100)
+        ELSE 
+            NULL
+    END AS sales_growth_rate,
+    CASE 
+        WHEN prev_month_profit > 0 THEN 
+            ((total_profit - prev_month_profit) / prev_month_profit * 100)
+        ELSE 
+            NULL
+    END AS profit_growth_rate,
+    RANK() OVER (PARTITION BY sale_month ORDER BY total_profit DESC) AS profit_rank
+FROM 
+    prev_month_data
+WHERE 
+    sale_month = (SELECT MAX(sale_month) FROM monthly_sales)
+ORDER BY 
+    profit_rank;


### PR DESCRIPTION
This branch adds profit margin calculation to the analysis. Changes:

Added total_profit calculation in the monthly_sales CTE. Renamed prev_month_sales to prev_month_data and added profit tracking. Added profit margin, profit growth rate, and profit ranking to the final SELECT.